### PR TITLE
Set halign of entry_contenttoqr center

### DIFF
--- a/resources/ui/qrit.glade
+++ b/resources/ui/qrit.glade
@@ -244,6 +244,7 @@
               <object class="GtkEntry" id="entry_contenttoqr">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
+                <property name="valign">center</property>
               </object>
               <packing>
                 <property name="expand">False</property>


### PR DESCRIPTION
Gtk.Entry needs to be set `halign = Gtk.Align.CENTER` since 3.22.

## Before
![Screenshot from 2020-10-07 09-48-35](https://user-images.githubusercontent.com/26003928/95275085-841a0300-0882-11eb-865d-25a0952c94c8.png)

## After
![Screenshot from 2020-10-07 09-48-13](https://user-images.githubusercontent.com/26003928/95275081-81b7a900-0882-11eb-8e99-af01edeb7cd6.png)
