### PR TITLE
Package as Flatpak for elementary OS 6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 build/
 .vscode/
+.flatpak-builder
 
-*.glade~
-*.ui~
+*~

--- a/com.github.sergius02.qrit.yml
+++ b/com.github.sergius02.qrit.yml
@@ -1,0 +1,29 @@
+app-id: com.github.sergius02.qrit
+
+runtime: io.elementary.Platform
+runtime-version: '6'
+sdk: io.elementary.Sdk
+
+command: com.github.sergius02.qrit
+
+finish-args:
+  - '--share=ipc'
+  - '--socket=fallback-x11'
+  - '--socket=wayland'
+  - '--filesystem=home'
+  # TODO: uncomment this when adding dark style support
+  # - '--system-talk-name=org.freedesktop.Accounts'
+
+modules:
+  - name: qrencode
+    buildsystem: cmake-ninja
+    sources:
+      - type: archive
+        url: https://fukuchi.org/works/qrencode/qrencode-4.1.1.tar.gz
+        sha512: 209bb656ae3f391b03c7b3ceb03e34f7320b0105babf48b619e7a299528b8828449e0e7696f0b5db0d99170a81709d0518e34835229a748701e7df784e58a9ce 
+
+  - name: qrit
+    buildsystem: meson
+    sources:
+      - type: dir
+        path: .

--- a/data/com.github.sergius02.qrit.appdata.xml.in
+++ b/data/com.github.sergius02.qrit.appdata.xml.in
@@ -11,8 +11,8 @@
     <p>This application use the incredible qrencode.</p>
   </description>
   <categories>
-​    <category>GTK</category>
-​    <category>Utility</category>
+    <category>GTK</category>
+    <category>Utility</category>
     <category>Development</category>
     <category>Network</category>
   </categories>


### PR DESCRIPTION
Closes #34.

This PR adds a Flatpak manifest file so that QRit can be submitted to AppCenter for elementary OS 6.

You can build and install the Flatpak using the following command:

```sh
flatpak-builder build com.github.sergius02.qrit.yml --user --force-clean --install
```

I have tested it, and all functions work fine in the Flatpak build.

If/when you merge this PR and are ready to submit the app to AppCenter, please publish a new GitHub release. After that, either make a pull request to the [appcenter-reviews repo](https://github.com/elementary/appcenter-reviews), or let Daniel know in #34 so he can manually add it to the Flatpak repo.

Let me know if you need any other help. Cheers! :relaxed: 
